### PR TITLE
Optimize twin creation

### DIFF
--- a/sdks/csharp/adtIotHub_allocate.cs
+++ b/sdks/csharp/adtIotHub_allocate.cs
@@ -105,42 +105,48 @@ namespace Samples.AdtIothub
                     Transport = new HttpClientTransport(singletonHttpClientInstance)
                 });
 
-            // Find existing twin with registration ID
+            // Find existing DigitalTwin with registration ID
             
             try
             {
-                // Get twin with Id `regId`
+                // Get DigitalTwin with Id `regId`
                 BasicDigitalTwin dt = await GetDigitalTwin<BasicDigitalTwin>(regId).ConfigureAwait(false);
 
                 // Check to make sure it is of model type `dtmi`
-                if (dt.Metadata.ModelId.Equals(dtmi, StringComparison.OrdinalIgnoreCase)
+                if (StringComparer.OrdinalIgnoreCase.Equals(dtmi, dt.Metadata.ModelId))
                 {
                     return dt.Id;
                 }
-                else
-                {
-                    // Found digital twin with `regId` but it is not of model type `dtmi`
-                    log.LogInformation($"Found digital twin {dt.Id} but it is not of model {dtmi}");
-                    return null;
-                }
+
+                // Found DigitalTwin with `regId` but it is not of model type `dtmi`
+                log.LogInformation($"Found DigitalTwin {dt.Id} but it is not of model {dtmi}");
             }
             catch(RequestFailedException ex) when (ex.Status == (int)HttpStatusCode.NotFound)
             {
-                // Digital twin not found, so we will create a new one.
-                BasicDigitalTwin dt = await client.CreateOrReplaceDigitalTwinAsync(
-                    regId, 
-                    new BasicDigitalTwin
-                    {
-                        Metadata = { ModelId = dtmi },
-                        Contents = 
-                        {
-                            { "Temperature", 0.0 }
-                        }
-                    }).ConfigureAwait(false);
-
-                log.LogInformation($"Digital Twin '{dtId}' created.");
-                return dt.Id;
+                log.LogInformation($"Did not find DigitalTwin {dt.Id}");
             }
+
+            // Either the DigitalTwin was not found, or we found it but it is of a different model type
+            // Create or replace it with what it needs to be. Meaning if it was not found a brand new DigitalTwin will be created
+            // and if it was of a different model, it will be replace that existing DigitalTwin
+            // If it was intended to only create the DigitalTwin if there is no matching DigitalTwin with the same Id,
+            // ETag.All would have been used as the ifNonMatch parameter to the CreateOrReplaceDigitalTwinAsync method call.
+            // Read more in the CreateOrReplaceDigitalTwinAsync documentation here:
+            // https://docs.microsoft.com/en-us/dotnet/api/azure.digitaltwins.core.digitaltwinsclient.createorreplacedigitaltwinasync?view=azure-dotnet
+            BasicDigitalTwin dt = await client.CreateOrReplaceDigitalTwinAsync(
+                regId, 
+                new BasicDigitalTwin
+                {
+                    Metadata = { ModelId = dtmi },
+                    Contents = 
+                    {
+                        { "Temperature", 0.0 }
+                    }
+                }
+            ).ConfigureAwait(false);
+
+            log.LogInformation($"Digital Twin '{dtId}' created.");
+            return dt.Id;
         }
     }
 

--- a/sdks/csharp/adtIotHub_allocate.cs
+++ b/sdks/csharp/adtIotHub_allocate.cs
@@ -127,10 +127,10 @@ namespace Samples.AdtIothub
             }
 
             // Either the DigitalTwin was not found, or we found it but it is of a different model type
-            // Create or replace it with what it needs to be. Meaning if it was not found a brand new DigitalTwin will be created
-            // and if it was of a different model, it will be replace that existing DigitalTwin
+            // Create or replace it with what it needs to be, meaning if it was not found a brand new DigitalTwin will be created
+            // and if it was of a different model, it will replace that existing DigitalTwin
             // If it was intended to only create the DigitalTwin if there is no matching DigitalTwin with the same Id,
-            // ETag.All would have been used as the ifNonMatch parameter to the CreateOrReplaceDigitalTwinAsync method call.
+            // ETag.All could have been used as the ifNonMatch parameter to the CreateOrReplaceDigitalTwinAsync method call.
             // Read more in the CreateOrReplaceDigitalTwinAsync documentation here:
             // https://docs.microsoft.com/en-us/dotnet/api/azure.digitaltwins.core.digitaltwinsclient.createorreplacedigitaltwinasync?view=azure-dotnet
             BasicDigitalTwin dt = await client.CreateOrReplaceDigitalTwinAsync(

--- a/sdks/csharp/adtIotHub_allocate.cs
+++ b/sdks/csharp/adtIotHub_allocate.cs
@@ -121,6 +121,7 @@ namespace Samples.AdtIothub
                 {
                     // Found digital twin with `regId` but it is not of model type `dtmi`
                     log.LogInformation($"Found digital twin {dt.Id} but it is not of model {dtmi}");
+                    return null;
                 }
             }
             catch(RequestFailedException ex) when (ex.Status == (int)HttpStatusCode.NotFound)


### PR DESCRIPTION
Running a query and finding a digital twin with a certain ID is wasteful as you can achieve the same thing using a GET call. There can't be more than a single digital twin with a certain ID in a DT instance. 