### PR TITLE
Add sub-property patch code

### DIFF
--- a/models/README.md
+++ b/models/README.md
@@ -17,6 +17,8 @@ Below is a list of the model files contained in this folder, including mappings 
 | patch-component.json | [how-to-manage-twin](https://docs.microsoft.com/azure/digital-twins/how-to-manage-twin) | Patch example that replaces a component's property |
 | patch-model-1.json | [how-to-manage-twin](https://docs.microsoft.com/azure/digital-twins/how-to-manage-twin) | Patch example that replaces the twin's model, when the twin conforms to new model already |
 | patch-model-2.json | [how-to-manage-twin](https://docs.microsoft.com/azure/digital-twins/how-to-manage-twin) | Patch example that replaces the twin's model, when the twin needs editing to conform to new model |
+| patch-object-sub-property-1.json | [how-to-manage-twin](https://docs.microsoft.com/azure/digital-twins/how-to-manage-twin) | Patch example that replaces a sub-property belonging to an object-type property of a twin -- step 1 |
+| patch-object-sub-property-2.json | [how-to-manage-twin](https://docs.microsoft.com/azure/digital-twins/how-to-manage-twin) | Patch example that replaces a sub-property belonging to an object-type property of a twin -- step 2 |
 | patch.json | [how-to-manage-twin](https://docs.microsoft.com/azure/digital-twins/how-to-manage-twin) | Basic patch example, replaces two properties |
 | PatientRoom.json | [how-to-manage-model](https://docs.microsoft.com/azure/digital-twins/how-to-manage-model) | General model example, with three properties and a relationship |
 | Planet-Crater-Moon.json | [concepts-models](https://docs.microsoft.com/azure/digital-twins/concepts-models) | Full model example, showing all field types |

--- a/models/patch-object-sub-property-1.json
+++ b/models/patch-object-sub-property-1.json
@@ -1,0 +1,7 @@
+[
+  {
+    "op": "add", 
+    "path": "/ObjectProperty", 
+    "value": {"StringSubProperty":"<string-value>"}
+  }
+]

--- a/models/patch-object-sub-property-2.json
+++ b/models/patch-object-sub-property-2.json
@@ -1,0 +1,7 @@
+[
+  {
+    "op": "replace",
+    "path": "/ObjectProperty/StringSubProperty",
+    "value": "<string-value>"
+  }
+]


### PR DESCRIPTION
## Purpose
Add code for a new docs example, patching sub-properties of object-type properties.
https://docs.microsoft.com/en-us/azure/digital-twins/how-to-manage-twin#update-sub-properties-in-object-type-properties

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```