### PR TITLE
Removed "DefaultAzureCredential_basic" code snippet

### DIFF
--- a/sdks/csharp/authentication.cs
+++ b/sdks/csharp/authentication.cs
@@ -23,14 +23,6 @@ catch(Exception e)
 }
 // </DefaultAzureCredential_full>
 
-// ------------------ DefaultAzureCredential (Basic) ------------------ 
-// <DefaultAzureCredential_basic>
-// Authenticate against the service and create a client
-string adtInstanceUrl = "https://<your-Azure-Digital-Twins-instance-hostName>";
-var credential = new DefaultAzureCredential();
-DigitalTwinsClient client = new DigitalTwinsClient(new Uri(adtInstanceUrl), credential);
-// </DefaultAzureCredential_basic>
-
 // ------------------ ManagedIdentityCredential ------------------
 // <ManagedIdentityCredential>
 ManagedIdentityCredential cred = new ManagedIdentityCredential(adtAppId);


### PR DESCRIPTION
Hey @baanders, looks like the only code snippet that's no longer in use since the previous PR is the "DefaultAzureCredential_basic" block.
