### PR TITLE
uppercased instances of the 'is_defined' function to maintain consistency

### DIFF
--- a/queries/examples.sql
+++ b/queries/examples.sql
@@ -28,7 +28,7 @@ SELECT *​ FROM DIGITALTWINS WHERE IS_DEFINED(Location)
 
 -- (Shows property query based on marker tags)
 -- <QueryMarkerTags1>
-SELECT * FROM DIGITALTWINS WHERE is_defined(tags.red)
+SELECT * FROM DIGITALTWINS WHERE IS_DEFINED(tags.red)
 -- </QueryMarkerTags1>
 
 -- (Shows property query based on property type)
@@ -230,12 +230,12 @@ AND IS_OF_MODEL(Room, 'dtmi:contoso:com:DigitalTwins:Room;1')
 
 -- (Shows property query that includes two marker tags)
 -- <QueryMarkerTags2>
-SELECT * FROM DIGITALTWINS WHERE NOT is_defined(tags.red) AND is_defined(tags.round)
+SELECT * FROM DIGITALTWINS WHERE NOT IS_DEFINED(tags.red) AND IS_DEFINED(tags.round)
 -- </QueryMarkerTags2>
 
 -- (Shows property query that includes one marker and one value tag)
 -- <QueryMarkerValueTags>
-SELECT * FROM DIGITALTWINS WHERE NOT is_defined(tags.red) AND tags.size = 'small'
+SELECT * FROM DIGITALTWINS WHERE NOT IS_DEFINED(tags.red) AND tags.size = 'small'
 -- </QueryMarkerValueTags>
 
 -------------- Used in tutorial-end-to-end


### PR DESCRIPTION
Hi @baanders,

This PR includes a small change to swap "is_defined()" to "IS_DEFINED()" to maintain consistency as it looks like the rest of the query functions are all uppercase form.

Thanks,
Gil