### PR TITLE
Split classes for twin operations

### DIFF
--- a/sdks/csharp/twin_operations_other.cs
+++ b/sdks/csharp/twin_operations_other.cs
@@ -41,7 +41,8 @@ namespace DigitalTwins_Samples
         public DigitalTwinPropertyMetadata Humidity { get; set; }
     }
 
-    public class TwinOperationsSamples
+    // Initialize properties and create the twin
+    public class TwinOperationsCreateTwin
     {
         public async Task CreateTwinAsync(DigitalTwinsClient client)
         {
@@ -57,9 +58,12 @@ namespace DigitalTwins_Samples
             const string twinId = "<twin-ID>";
             Response<CustomDigitalTwin> response = await client.CreateOrReplaceDigitalTwinAsync(twinId, myTwin);
             Console.WriteLine($"Temperature last updated on {response.Value.Metadata.Temperature.LastUpdatedOn}");
-            // </CreateTwin_noHelper>
         }
+    }
+    // </CreateTwin_noHelper>
 
+    public class TwinOperationsOther
+    { 
         public async Task UpdateTwinAsync(DigitalTwinsClient client)
         {
             // ------------------ UPDATE TWIN (Longer example than in the runnable sample)---------------------
@@ -96,4 +100,4 @@ namespace DigitalTwins_Samples
             // </TagPropertiesCsharp>
             }
         }
-}
+    }

--- a/sdks/csharp/twin_operations_other.cs
+++ b/sdks/csharp/twin_operations_other.cs
@@ -98,6 +98,6 @@ namespace DigitalTwins_Samples
             };
             await client.CreateOrReplaceDigitalTwinAsync<BasicDigitalTwin>("myTwinID", twin);
             // </TagPropertiesCsharp>
-            }
         }
     }
+}


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
A customer submitted an issue noting that a code snippet in the document using twin_operations_other.cs did not include two closing brackets for the method and the class in the sample displayed by the <CreateTwin_noHelper> tag.
This PR remedies this situation by:
* Closing the class after the content used by <CreateTwin_noHelper>
* Moving the end of the </CreateTwin_noHelper> tag after the method-closing bracket and the new class-closing bracket
* Adding a new class for the remaining samples that were originally in the same class as <CreateTwin_noHelper> and are now outside of it.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[X] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
Build project and check for syntax errors

## Other information:
Link to customer issue: https://github.com/MicrosoftDocs/azure-docs/issues/84467