### PR TITLE
Bypass signature error for IoT Hub ingestion

### DIFF
--- a/sdks/csharp/IotHubToTwins.cs
+++ b/sdks/csharp/IotHubToTwins.cs
@@ -19,7 +19,10 @@ namespace IotHubtoTwins
         private static readonly HttpClient httpClient = new HttpClient();
 
         [FunctionName("IoTHubtoTwins")]
+        // While async void should generally be used with caution, it's not uncommon for Azure function apps, since the function app isn't awaiting the task.
+#pragma warning disable AZF0001 // Suppress async void error
         public async void Run([EventGridTrigger] EventGridEvent eventGridEvent, ILogger log)
+#pragma warning restore AZF0001 // Suppress async void error
         {
             if (adtInstanceUrl == null) log.LogError("Application setting \"ADT_SERVICE_URL\" not set");
 


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
While async void should generally be used with caution, it's not uncommon for Azure function apps, since the function app isn't awaiting the task. This PR adds code to bypass the async void error in the Azure function for IoT Hub ingestion.