### PR TITLE
Telemetry > Property in doc samples

### DIFF
--- a/models/CelestialBody-Planet-Crater.json
+++ b/models/CelestialBody-Planet-Crater.json
@@ -16,7 +16,7 @@
         "schema": "double"
       },
       {
-        "@type": "Telemetry",
+        "@type": "Property",
         "name": "temperature",
         "schema": "double"
       }

--- a/models/Planet-Crater-Moon.json
+++ b/models/Planet-Crater-Moon.json
@@ -16,7 +16,7 @@
           "schema": "double"
         },
         {
-          "@type": "Telemetry",
+          "@type": "Property",
           "name": "Temperature",
           "schema": "double"
         },


### PR DESCRIPTION
According to the product team's latest recommendation, customers should use DTDL **properties** to store twin state information, and DTDL’s **telemetry** feature has no unique purpose in Azure Digital Twins. This PR updates Azure Digital Twins samples accordingly to use properties instead of telemetry.