### PR TITLE
Updated target framework & package references, resolved conversion error

### DIFF
--- a/sdks/csharp/DigitalTwins Samples.csproj
+++ b/sdks/csharp/DigitalTwins Samples.csproj
@@ -2,22 +2,22 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RootNamespace>DigitalTwins_Samples</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Azure.DigitalTwins.Core" Version="1.4.0" />
-    <PackageReference Include="Azure.Identity" Version="1.8.0" />
-    <PackageReference Include="Azure.Messaging.EventGrid" Version="4.12.0" />
-    <PackageReference Include="Azure.Messaging.EventHubs" Version="5.7.5" />
-    <PackageReference Include="dotNetRDF" Version="2.7.5" />
-    <PackageReference Include="DTDLParser" Version="1.0.48-preview-g91a6ae2e88" />
-    <PackageReference Include="Microsoft.Azure.WebJobs.Core" Version="3.0.33" />
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.EventGrid" Version="3.2.1" />
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.EventHubs" Version="5.1.2" />
+    <PackageReference Include="Azure.Identity" Version="1.13.2" />
+    <PackageReference Include="Azure.Messaging.EventGrid" Version="4.30.0" />
+    <PackageReference Include="Azure.Messaging.EventHubs" Version="5.11.6" />
+    <PackageReference Include="dotNetRDF" Version="3.3.2" />
+    <PackageReference Include="DTDLParser" Version="1.1.3" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Core" Version="3.0.41" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.EventGrid" Version="3.4.3" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.EventHubs" Version="6.3.5" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Http" Version="3.2.0" />
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.SignalRService" Version="1.8.0" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.SignalRService" Version="2.0.0" />
   </ItemGroup>
 
 </Project>

--- a/sdks/csharp/updateTSI.cs
+++ b/sdks/csharp/updateTSI.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Azure.Messaging.EventHubs;
+using System.Runtime.InteropServices;
 
 namespace UpdateTSI
 {
@@ -17,7 +18,7 @@ namespace UpdateTSI
             [EventHub("tsi-event-hub", Connection = "EventHubAppSetting-TSI")]IAsyncCollector<string> outputEvents,
             ILogger log)
         {
-            JObject message = (JObject)JsonConvert.DeserializeObject(Encoding.UTF8.GetString(myEventHubMessage.Body));
+            JObject message = (JObject)JsonConvert.DeserializeObject(Encoding.UTF8.GetString(myEventHubMessage.Body.ToArray()));
             log.LogInformation($"Reading event: {message}");
 
             // Read values that are replaced or added


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Obsolete `TargetFramework` and `PackageReference` values in `DigitalTwins Samples.csproj`
* Compilation error: `C:\GitHub\digital-twins-docs-code\sdks\csharp\updateTSI.cs(20,94): error CS1503: Argument 1: cannot convert from 'System.ReadOnlyMemory<byte>' to 'byte[]`

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[X] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code
  ```
  git clone [repo-address]
  cd [repo-name]
  git checkout [branch-name]
  npm install
  ```

* Test the code
  * Ensure that you specify a <StartupObject> for DigitalTwins_Samples.DigitalTwinsClientAppSample, or specify that entry point when issuing a `dotnet` command in terminal to start the application.
    ```
    \sdks\csharp\DigitalTwins Samples.csproj
    <PropertyGroup>
      ...
      <StartupObject>DigitalTwins_Samples.DigitalTwinsClientAppSample</StartupObject>
    </PropertyGroup>
    ```
    or
    ```
    dotnet run --property:StartupObject=DigitalTwins_Samples.DigitalTwinsClientAppSample
    ```
  * Ensure that you follow the instructions as provided in documentation to configure the following variables:
    * \sdks\csharp\fullClientApp.cs, line 26: replace placeholder with a valid Digital Twins instance host name
    * \sdks\csharp\fullClientApp.cs, line 36: replace SampleModel.json with the full path and file name to \models\SampleModel.json

## What to Check
Verify that the following are valid
* No warnings with the following codes are present in console output during compilation: NETSDK1138, NU1902, NU1903
* No errors are present in console output during compilation
* When run, the sample uses the specified startup object and runs to completion without error.

## Other Information
* I did not address the following error because the implementation appears intentional, so that the project can support multiple startup objects:
 ```C:\GitHub\digital-twins-docs-code\sdks\csharp\fullClientApp.cs(21,27): error CS0017: Program has more than one entry point defined. Compile with /main to specify the type that contains the entry point.```
I've included testing instructions on how to specify the relevant entry point.
* I did not address the following warning because it was non-blocking, but it should be reviewed for best practices:
```\sdks\csharp\queries.cs(10,27): warning CS1998: This async method lacks 'await' operators and will run synchronously. Consider using the 'await' operator to await non-blocking API calls, or 'await Task.Run(...)' to do CPU-bound work on a background thread.```