### PR TITLE
Removed zero-width spaces from 3 queries in /queries/examples.sql

### DIFF
--- a/queries/examples.sql
+++ b/queries/examples.sql
@@ -23,7 +23,7 @@ AND T.Temperature = 70
 
 -- (Shows property query based on whether property is defined)
 -- <QueryByProperty2>
-SELECT *​ FROM DIGITALTWINS WHERE IS_DEFINED(Location)
+SELECT * FROM DIGITALTWINS WHERE IS_DEFINED(Location)
 -- </QueryByProperty2>
 
 -- (Shows property query based on marker tags)
@@ -33,12 +33,12 @@ SELECT * FROM DIGITALTWINS WHERE IS_DEFINED(tags.red)
 
 -- (Shows property query based on property type)
 -- <QueryByProperty3>
-SELECT * FROM DIGITALTWINS​ T WHERE IS_NUMBER(T.Temperature)
+SELECT * FROM DIGITALTWINS T WHERE IS_NUMBER(T.Temperature)
 -- </QueryByProperty3>
 
 -- (Shows property query with a Map-type property)
 -- <QueryByProperty4>
-SELECT * FROM DIGITALTWINS​ T WHERE T.<propertyName>.<mapKey> = '<mapValue>'
+SELECT * FROM DIGITALTWINS T WHERE T.<propertyName>.<mapKey> = '<mapValue>'
 -- </QueryByProperty4>
 
 -- (Shows model query with only twinTypeName parameter)


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->

* Presence of zero-width spaces in ADT queries causes a parser error. 
  For example, copying & running such a query into Azure Digital Twins Explorer returns the following error:
  ```
  RestError: {"error":{"code":"SqlQueryError","message":"SQL query parse failed: SQL Parser Error, Line=1, Position=8, 
  Message=extraneous input '​' expecting {, FROM, GROUP, WHERE} See samples in https://aka.ms/adtv2query for the correct syntax."}}
        at new t (https://explorer.digitaltwins.azure.net/static/js/main.1bd8494d.js:2:688920)
        at https://explorer.digitaltwins.azure.net/static/js/main.1bd8494d.js:2:694220
        at https://explorer.digitaltwins.azure.net/static/js/main.1bd8494d.js:2:694905
  ```

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

```
[ ] Yes
[X] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[X] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

*  Get the code
```
git clone https://github.com/DENKEN02MSFT/digital-twins-docs-code.git
cd digital-twins-docs-code
git checkout ADTFreshnessTop40_Row33
npm install
```

* Test the code
```
* Open /queries/examples.sql, and copy any of the queries on the following lines: 26, 36, or 41.
* Open Azure Digital Twins Explorer and paste the copied query into the **Query** text box.
* Select **Run Query**
```

## What to Check

Verify that the following are valid:
* There are no zero-width spaces present in any query in /queries/examples.sql
* That, when a query is copied from that file into Azure Digital Twins Explorer, it runs without error. 
  The query might not return results - that's expected behavior depending on the instance and models being used - but it must not return a `SqlQueryError` error.

## Other Information
<!-- Add any other helpful information that may be needed here. -->

None.